### PR TITLE
Correct Schema for StringFormat

### DIFF
--- a/kirun-java/pom.xml
+++ b/kirun-java/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>com.fincity.nocode</groupId>
 	<artifactId>kirun-java</artifactId>
-	<version>1.4.7</version>
+	<version>1.4.9</version>
 	<name>kirun-java</name>
 	<description>Interpreter to execute the visual code on the Java layer</description>
 	<properties>

--- a/kirun-java/pom.xml
+++ b/kirun-java/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>com.fincity.nocode</groupId>
 	<artifactId>kirun-java</artifactId>
-	<version>1.4.12</version>
+	<version>1.4.13</version>
 	<name>kirun-java</name>
 	<description>Interpreter to execute the visual code on the Java layer</description>
 	<properties>

--- a/kirun-java/pom.xml
+++ b/kirun-java/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>com.fincity.nocode</groupId>
 	<artifactId>kirun-java</artifactId>
-	<version>1.4.13</version>
+	<version>1.4.14</version>
 	<name>kirun-java</name>
 	<description>Interpreter to execute the visual code on the Java layer</description>
 	<properties>

--- a/kirun-java/src/main/java/com/fincity/nocode/kirun/engine/json/schema/validator/SchemaValidator.java
+++ b/kirun-java/src/main/java/com/fincity/nocode/kirun/engine/json/schema/validator/SchemaValidator.java
@@ -38,6 +38,11 @@ public class SchemaValidator {
 			return enumCheck(parents, schema, element);
 		}
 
+        if (schema.getFormat() != null && schema.getType() == null) {
+            throw new SchemaValidationException(path(parents),
+                    "Type is missing in schema for declared " + schema.getFormat().toString() + " format.");
+        }
+		
 		if (schema.getType() != null) {
 			typeValidation(parents, schema, repository, element);
 		}
@@ -115,7 +120,7 @@ public class SchemaValidator {
 		if (!valid) {
 			throw new SchemaValidationException(path(parents), "Value " + element + " is not of valid type(s)", list);
 		}
-	}
+	}	
 
 	public static String path(List<Schema> parents) {
 

--- a/kirun-java/src/test/java/com/fincity/nocode/kirun/engine/json/schema/SchemaValidatorTest.java
+++ b/kirun-java/src/test/java/com/fincity/nocode/kirun/engine/json/schema/SchemaValidatorTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -188,5 +189,26 @@ class SchemaValidatorTest {
 		assertThrows(SchemaValidationException.class, () -> SchemaValidator.validate(null, schema, null, element));
 
 	}
+	
+	@Test
+	void schemaValidatorForObjectWhenTypeMissing() {
+	    
+	    JsonObject defaultValue = new JsonObject();
+        defaultValue.addProperty("value", 123);
+	    
+	    Schema schema = Schema.ofObject("testSchema").setProperties(Map.of("intType" ,new Schema()));
+	    
+	    assertEquals(defaultValue, SchemaValidator.validate(null, schema, null, defaultValue));
+	}
 
+	@Test
+	void schemaValidatorForStringWhenTypeMissing() {
+	    
+	       JsonObject defaultValue = new JsonObject();
+	        defaultValue.addProperty("value", "surendhar.s");
+	        
+	        Schema schema = Schema.ofObject("testSchema").setProperties(Map.of("stringType" ,new Schema()));
+	        
+	        assertEquals(defaultValue, SchemaValidator.validate(null, schema, null, defaultValue));
+	}
 }

--- a/kirun-java/src/test/java/com/fincity/nocode/kirun/engine/json/schema/StringFormatSchemaValidatorTest.java
+++ b/kirun-java/src/test/java/com/fincity/nocode/kirun/engine/json/schema/StringFormatSchemaValidatorTest.java
@@ -1,0 +1,256 @@
+package com.fincity.nocode.kirun.engine.json.schema;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fincity.nocode.kirun.engine.json.schema.string.StringFormat;
+import com.fincity.nocode.kirun.engine.json.schema.type.SchemaType;
+import com.fincity.nocode.kirun.engine.json.schema.type.Type;
+import com.fincity.nocode.kirun.engine.json.schema.validator.SchemaValidator;
+import com.fincity.nocode.kirun.engine.json.schema.validator.exception.SchemaValidationException;
+import com.google.gson.JsonObject;
+
+class StringFormatSchemaValidatorTest {
+
+    @Test
+    void schemaVerifyForStringFormatInObject() {
+
+        JsonObject def = new JsonObject();
+        def.addProperty("value", "1997-11-21");
+        Schema dateSchema = new Schema().setFormat(StringFormat.DATE).setName("dateSchema");
+// as String schema type was not declared it will throw error
+
+        Schema schema = Schema.ofObject("dateTest")
+                .setProperties(Map.of("value", dateSchema, "intSc", Schema.ofInteger("intSchema")))
+                .setRequired(List.of("value"));
+
+        SchemaValidationException schemaEx = assertThrows(SchemaValidationException.class,
+                () -> SchemaValidator.validate(null, schema, null, def));
+
+        assertEquals("dateTest - Value {\"value\":\"1997-11-21\"} is not of valid type(s)\n"
+                + "dateTest.dateSchema - Type is missing in schema for declared " + dateSchema.getFormat().toString()
+                + " format.", schemaEx.getMessage());
+    }
+
+    @Test
+    void schemaVerifyForIntegerInObject() {
+
+        JsonObject def = new JsonObject();
+        def.addProperty("value", "1997");
+
+        Schema schema = Schema.ofObject("intTest")
+                .setProperties(Map.of("value", Schema.ofInteger("intSchema")));
+
+        assertThrows(SchemaValidationException.class, () -> SchemaValidator.validate(null, schema, null, def));
+    }
+
+    @Test
+    void schemaVerifyForInteger() {
+
+        JsonObject def = new JsonObject();
+        def.addProperty("value", 1997);
+
+        Schema schema = Schema.ofInteger("intTest")
+                .setMinimum(2000);
+
+        assertThrows(SchemaValidationException.class, () -> SchemaValidator.validate(null, schema, null, def));
+    }
+
+    @Test
+    void schemaVerifyForStringFormatIntInObject() {
+
+        JsonObject def = new JsonObject();
+        def.addProperty("value", "1997-11-21");
+        def.addProperty("intSc", 4);
+        Schema dateSchema = new Schema().setFormat(StringFormat.DATE).setName("dateSchema")
+                .setType(Type.of(SchemaType.STRING));
+
+        Schema schema = Schema.ofObject("dateTest")
+                .setProperties(Map.of("value", dateSchema, "intSc",
+                        Schema.ofInteger("intSchema").setMaximum(12).setMultipleOf(2l)))
+                .setRequired(List.of("value"));
+
+        assertEquals(SchemaValidator.validate(null, schema, null, def), def);
+    }
+
+    @Test
+    void schemaVerifyForStringFormatEmailStringMissingInTypeObject() {
+
+        JsonObject def = new JsonObject();
+        def.addProperty("email", "iosdjfdf123--@gmail.com");
+        Schema emailSchema = new Schema().setFormat(StringFormat.EMAIL).setName("emailSchema");
+
+        Schema schema = Schema.ofObject("emailTest")
+                .setProperties(Map.of("email", emailSchema))
+                .setRequired(List.of("email"));
+
+        SchemaValidationException emailExc = assertThrows(SchemaValidationException.class,
+                () -> SchemaValidator.validate(null, schema, null, def));
+        var msg = schema.getName() + " - " + "Value {\"email\":\"iosdjfdf123--@gmail.com\"} is not of valid type(s)\n" +
+                schema.getName() + "." + emailSchema.getName() + " - "
+                + "Type is missing in schema for declared EMAIL format.";
+        assertEquals(msg, emailExc.getMessage());
+    }
+
+    @Test
+    void schemaVerifyForStringFormatEmailWrongRegexInObject() {
+
+        JsonObject def = new JsonObject();
+        def.addProperty("email", "iosdjfdf123--@@gmail.com");
+        Schema emailSchema = new Schema().setFormat(StringFormat.EMAIL).setName("emailSchema")
+                .setType(Type.of(SchemaType.STRING));
+
+        Schema schema = Schema.ofObject("emailTest")
+                .setProperties(Map.of("email", emailSchema, "intSc",
+                        Schema.ofInteger("intSchema").setMaximum(12).setMultipleOf(2l)))
+                .setRequired(List.of("email"));
+
+        SchemaValidationException emailExc = assertThrows(SchemaValidationException.class,
+                () -> SchemaValidator.validate(null, schema, null, def));
+        var msg = schema.getName() + " - " + "Value {\"email\":\"iosdjfdf123--@@gmail.com\"} is not of valid type(s)\n"
+                +
+                schema.getName() + "." + emailSchema.getName() + " - "
+                + "Value \"iosdjfdf123--@@gmail.com\" is not of valid type(s)\n" +
+                schema.getName() + "." + emailSchema.getName() + " - "
+                + "\"iosdjfdf123--@@gmail.com\" is not matched with the email pattern";
+        assertEquals(msg, emailExc.getMessage());
+    }
+
+    @Test
+    void schemaVerifyForStringFormatEmailType() {
+
+        JsonObject def = new JsonObject();
+        def.addProperty("email", "iosdjfdf123--@gmail.com");
+        Schema emailSchema = new Schema().setFormat(StringFormat.EMAIL).setName("emailSchema")
+                .setType(Type.of(SchemaType.STRING));
+
+        Schema schema = Schema.ofObject("emailTest")
+                .setProperties(Map.of("email", emailSchema, "intSc",
+                        Schema.ofInteger("intSchema").setMaximum(12).setMultipleOf(2l)))
+                .setRequired(List.of("email"));
+        assertEquals(def, SchemaValidator.validate(null, schema, null, def));
+    }
+
+    @Test
+    void schemaVerifyForStringFormatTimeStringMissingInTypeObject() {
+
+        JsonObject def = new JsonObject();
+        def.addProperty("time", "23:12:43");
+        Schema timeSchema = new Schema().setFormat(StringFormat.TIME).setName("timeSchema");
+
+        Schema schema = Schema.ofObject("timeTest")
+                .setProperties(Map.of("time", timeSchema))
+                .setRequired(List.of("time"));
+
+        SchemaValidationException timeExc = assertThrows(SchemaValidationException.class,
+                () -> SchemaValidator.validate(null, schema, null, def));
+        var msg = schema.getName() + " - " + "Value {\"time\":\"23:12:43\"} is not of valid type(s)\n" +
+                schema.getName() + "." + timeSchema.getName() + " - "
+                + "Type is missing in schema for declared TIME format.";
+        assertEquals(msg, timeExc.getMessage());
+    }
+
+    @Test
+    void schemaVerifyForStringFormatTimeWrongRegexInObject() {
+
+        JsonObject def = new JsonObject();
+        def.addProperty("time", "24:12:23");
+        Schema timeSchema = new Schema().setFormat(StringFormat.TIME).setName("timeSchema")
+                .setType(Type.of(SchemaType.STRING));
+
+        Schema schema = Schema.ofObject("timeTest")
+                .setProperties(Map.of("time", timeSchema, "intSc",
+                        Schema.ofInteger("intSchema").setMaximum(12).setMultipleOf(2l)))
+                .setRequired(List.of("time"));
+
+        SchemaValidationException emailExc = assertThrows(SchemaValidationException.class,
+                () -> SchemaValidator.validate(null, schema, null, def));
+        var msg = schema.getName() + " - " + "Value {\"time\":\"24:12:23\"} is not of valid type(s)\n"
+                +
+                schema.getName() + "." + timeSchema.getName() + " - "
+                + "Value \"24:12:23\" is not of valid type(s)\n" +
+                schema.getName() + "." + timeSchema.getName() + " - "
+                + "\"24:12:23\" is not matched with the time pattern";
+        assertEquals(msg, emailExc.getMessage());
+    }
+
+    @Test
+    void schemaVerifyForStringFormatTimeType() {
+
+        JsonObject def = new JsonObject();
+        def.addProperty("time", "14:34:45");
+        Schema emailSchema = new Schema().setFormat(StringFormat.TIME).setName("timeSchema")
+                .setType(Type.of(SchemaType.STRING));
+
+        Schema schema = Schema.ofObject("timeTest")
+                .setProperties(Map.of("time", emailSchema, "intSc",
+                        Schema.ofInteger("intSchema").setMaximum(12).setMultipleOf(2l)))
+                .setRequired(List.of("time"));
+        assertEquals(def, SchemaValidator.validate(null, schema, null, def));
+    }
+
+    @Test
+    void schemaVerifyForStringFormatDateTimeStringMissingInTypeObject() {
+
+        JsonObject def = new JsonObject();
+        def.addProperty("datetime", "2023-08-21T07:56:45+12:12");
+        Schema datetimeSchema = new Schema().setFormat(StringFormat.DATETIME).setName("dateTimeSchema");
+
+        Schema schema = Schema.ofObject("datetimeTest")
+                .setProperties(Map.of("datetime", datetimeSchema))
+                .setRequired(List.of("datetime"));
+
+        SchemaValidationException timeExc = assertThrows(SchemaValidationException.class,
+                () -> SchemaValidator.validate(null, schema, null, def));
+        var msg = schema.getName() + " - "
+                + "Value {\"datetime\":\"2023-08-21T07:56:45+12:12\"} is not of valid type(s)\n" +
+                schema.getName() + "." + datetimeSchema.getName() + " - "
+                + "Type is missing in schema for declared DATETIME format.";
+        assertEquals(msg, timeExc.getMessage());
+    }
+
+    @Test
+    void schemaVerifyForStringFormatDateTimeWrongRegexInObject() {
+
+        JsonObject def = new JsonObject();
+        def.addProperty("datetime", "2023-08-21T07:56:45s+12:12");
+        Schema datetimeSchema = new Schema().setFormat(StringFormat.DATETIME).setName("datetimeSchema")
+                .setType(Type.of(SchemaType.STRING));
+
+        Schema schema = Schema.ofObject("datetimeTest")
+                .setProperties(Map.of("datetime", datetimeSchema, "intSc",
+                        Schema.ofInteger("intSchema").setMaximum(12).setMultipleOf(2l)))
+                .setRequired(List.of("datetime"));
+
+        SchemaValidationException emailExc = assertThrows(SchemaValidationException.class,
+                () -> SchemaValidator.validate(null, schema, null, def));
+        var msg = schema.getName() + " - "
+                + "Value {\"datetime\":\"2023-08-21T07:56:45s+12:12\"} is not of valid type(s)\n"
+                +
+                schema.getName() + "." + datetimeSchema.getName() + " - "
+                + "Value \"2023-08-21T07:56:45s+12:12\" is not of valid type(s)\n" +
+                schema.getName() + "." + datetimeSchema.getName() + " - "
+                + "\"2023-08-21T07:56:45s+12:12\" is not matched with the date time pattern";
+        assertEquals(msg, emailExc.getMessage());
+    }
+
+    @Test
+    void schemaVerifyForStringFormatDateTimeType() {
+
+        JsonObject def = new JsonObject();
+        def.addProperty("datetime", "2023-08-21T07:56:45+12:12");
+        Schema emailSchema = new Schema().setFormat(StringFormat.DATETIME).setName("datetimeSchema")
+                .setType(Type.of(SchemaType.STRING));
+
+        Schema schema = Schema.ofObject("datetimeTest")
+                .setProperties(Map.of("datetime", emailSchema, "intSc",
+                        Schema.ofInteger("intSchema").setMaximum(12).setMultipleOf(2l)))
+                .setRequired(List.of("datetime"));
+        assertEquals(def, SchemaValidator.validate(null, schema, null, def));
+    }
+}

--- a/kirun-js/__tests__/engine/json/schema/validator/StringFormatSchemaValidatorTest.ts
+++ b/kirun-js/__tests__/engine/json/schema/validator/StringFormatSchemaValidatorTest.ts
@@ -1,0 +1,299 @@
+import {
+    KIRunSchemaRepository,
+    Schema,
+    SchemaType,
+    SchemaValidator,
+    StringFormat,
+    Type,
+    TypeUtil,
+} from '../../../../../src';
+
+const repo = new KIRunSchemaRepository();
+
+test('Schema Validator fail with date test', () => {
+    let schema: Schema = new Schema().setType(TypeUtil.of(SchemaType.INTEGER));
+
+    expect(SchemaValidator.validate([], schema, repo, 2)).toBe(2);
+
+    let obj = { name: 'shagil' };
+    let objSchema: Schema = Schema.ofObject('testObj')
+        .setProperties(
+            new Map<string, Schema>([
+                ['name', Schema.ofString('name')],
+                ['date', new Schema().setFormat(StringFormat.DATE)],
+            ]),
+        )
+        .setRequired(['name', 'date']);
+
+    expect(() => SchemaValidator.validate([], objSchema, repo, obj)).toThrow('date is mandatory');
+    const dateObj = { name: 'surendhar.s', date: '1999-13-12' };
+    const errorMsg =
+        'Value {"name":"surendhar.s","date":"1999-13-12"} is not of valid type(s)' +
+        '\n' +
+        'Type is missing in schema for declared DATE format.';
+
+    expect(() => SchemaValidator.validate([], objSchema, repo, dateObj)).toThrow(errorMsg);
+});
+
+test('Schema Validator pass with date test ', () => {
+    let intSchema: Schema = new Schema().setType(TypeUtil.of(SchemaType.INTEGER)).setMinimum(100);
+
+    let objSchema: Schema = Schema.ofObject('testObj')
+        .setProperties(
+            new Map<string, Schema>([
+                ['intSchema', intSchema],
+                ['name', Schema.ofString('name')],
+                [
+                    'date',
+                    new Schema()
+                        .setFormat(StringFormat.DATE)
+                        .setType(TypeUtil.of(SchemaType.STRING)),
+                ],
+            ]),
+        )
+        .setRequired(['intSchema', 'date']);
+
+    const dateObj = { intSchema: 1231, date: '1999-09-12' };
+
+    expect(SchemaValidator.validate([], objSchema, repo, dateObj)).toBe(dateObj);
+});
+
+test('Schema Validator fail with time string type missing test ', () => {
+    let intSchema: Schema = new Schema()
+        .setType(TypeUtil.of(SchemaType.INTEGER))
+        .setMaximum(100)
+        .setMultipleOf(5);
+
+    let objSchema: Schema = Schema.ofObject('testObj')
+        .setProperties(
+            new Map<string, Schema>([
+                ['intSchema', intSchema],
+                ['name', Schema.ofString('name').setMinLength(10)],
+                ['time', new Schema().setFormat(StringFormat.TIME)],
+            ]),
+        )
+        .setRequired(['intSchema', 'time', 'name']);
+
+    const timeObj = { intSchema: 95, time: '22:23:61', name: 's.surendhar' };
+
+    const errMsg =
+        'Value {"intSchema":95,"time":"22:23:61","name":"s.surendhar"} is not of valid type(s)\n' +
+        'Type is missing in schema for declared TIME format.';
+
+    expect(() => SchemaValidator.validate([], objSchema, repo, timeObj)).toThrow(errMsg);
+});
+
+test('Schema Validator fail with time test ', () => {
+    let intSchema: Schema = new Schema()
+        .setType(TypeUtil.of(SchemaType.INTEGER))
+        .setMaximum(100)
+        .setMultipleOf(5);
+
+    let objSchema: Schema = Schema.ofObject('testObj')
+        .setProperties(
+            new Map<string, Schema>([
+                ['intSchema', intSchema],
+                ['name', Schema.ofString('name').setMinLength(10)],
+                [
+                    'time',
+                    new Schema()
+                        .setFormat(StringFormat.TIME)
+                        .setType(TypeUtil.of(SchemaType.STRING)),
+                ],
+            ]),
+        )
+        .setRequired(['intSchema', 'time', 'name']);
+
+    const timeObj = { intSchema: 95, time: '22:23:61', name: 's.surendhar' };
+
+    const errMsg =
+        'Value {"intSchema":95,"time":"22:23:61","name":"s.surendhar"} is not of valid type(s)\n' +
+        'Value "22:23:61" is not of valid type(s)\n' +
+        '22:23:61 is not matched with the time pattern';
+
+    expect(() => SchemaValidator.validate([], objSchema, repo, timeObj)).toThrow(errMsg);
+});
+
+test('Schema Validator pass with time test ', () => {
+    let intSchema: Schema = new Schema()
+        .setType(TypeUtil.of(SchemaType.INTEGER))
+        .setMaximum(100)
+        .setMultipleOf(5);
+
+    let objSchema: Schema = Schema.ofObject('testObj')
+        .setProperties(
+            new Map<string, Schema>([
+                ['intSchema', intSchema],
+                ['name', Schema.ofString('name').setMinLength(10)],
+                [
+                    'time',
+                    new Schema()
+                        .setFormat(StringFormat.TIME)
+                        .setType(TypeUtil.of(SchemaType.STRING)),
+                ],
+            ]),
+        )
+        .setRequired(['intSchema', 'time', 'name']);
+
+    const timeObj = { intSchema: 95, time: '22:23:24', name: 's.surendhar' };
+
+    expect(SchemaValidator.validate([], objSchema, repo, timeObj)).toBe(timeObj);
+});
+
+test('Schema Validator fail with email string type missing test ', () => {
+    let intSchema: Schema = new Schema().setType(TypeUtil.of(SchemaType.INTEGER)).setMaximum(100);
+
+    let objSchema: Schema = Schema.ofObject('testObj')
+        .setProperties(
+            new Map<string, Schema>([
+                ['intSchema', intSchema],
+                ['name', Schema.ofString('name').setMinLength(10)],
+                ['email', new Schema().setFormat(StringFormat.EMAIL)],
+            ]),
+        )
+        .setRequired(['intSchema', 'email', 'name']);
+
+    const emailObj = { intSchema: 95, email: 'iosdjfdf123--@gmail.com', name: 's.surendhar' };
+
+    const errMsg =
+        'Value {"intSchema":95,"email":"iosdjfdf123--@gmail.com","name":"s.surendhar"} is not of valid type(s)\n' +
+        'Type is missing in schema for declared EMAIL format.';
+
+    expect(() => SchemaValidator.validate([], objSchema, repo, emailObj)).toThrow(errMsg);
+});
+
+test('Schema Validator fail with email test ', () => {
+    let intSchema: Schema = new Schema()
+        .setType(TypeUtil.of(SchemaType.INTEGER))
+        .setMaximum(3)
+        .setMultipleOf(5);
+
+    let objSchema: Schema = Schema.ofObject('testObj')
+        .setProperties(
+            new Map<string, Schema>([
+                ['intSchema', intSchema],
+                ['name', Schema.ofString('name').setMinLength(10)],
+                [
+                    'email',
+                    new Schema()
+                        .setFormat(StringFormat.EMAIL)
+                        .setType(TypeUtil.of(SchemaType.STRING)),
+                ],
+            ]),
+        )
+        .setRequired(['intSchema', 'email']);
+
+    const emailObj = { intSchema: 0, email: 'asdasdf@@*.com' };
+
+    const errMsg =
+        'Value {"intSchema":0,"email":"asdasdf@@*.com"} is not of valid type(s)\n' +
+        'Value "asdasdf@@*.com" is not of valid type(s)\n' +
+        'asdasdf@@*.com is not matched with the email pattern';
+
+    expect(() => SchemaValidator.validate([], objSchema, repo, emailObj)).toThrow(errMsg);
+});
+
+test('Schema Validator pass with time test ', () => {
+    let intSchema: Schema = new Schema().setType(TypeUtil.of(SchemaType.INTEGER));
+
+    let objSchema: Schema = Schema.ofObject('testObj')
+        .setProperties(
+            new Map<string, Schema>([
+                ['intSchema', intSchema],
+                ['name', Schema.ofString('name').setMinLength(10)],
+                [
+                    'email',
+                    new Schema()
+                        .setFormat(StringFormat.EMAIL)
+                        .setType(TypeUtil.of(SchemaType.STRING)),
+                ],
+            ]),
+        )
+        .setRequired(['intSchema', 'name']);
+
+    const emailObj = { intSchema: 95, email: 'surendhar.s@finc.c', name: 's.surendhar' };
+
+    expect(SchemaValidator.validate([], objSchema, repo, emailObj)).toBe(emailObj);
+});
+
+test('Schema Validator fail with dateTime string type missing test ', () => {
+    let intSchema: Schema = new Schema().setType(TypeUtil.of(SchemaType.INTEGER)).setMaximum(100);
+
+    let objSchema: Schema = Schema.ofObject('testObj')
+        .setProperties(
+            new Map<string, Schema>([
+                ['intSchema', intSchema],
+                ['name', Schema.ofString('name').setMinLength(10)],
+                ['dateTime', new Schema().setFormat(StringFormat.DATETIME)],
+            ]),
+        )
+        .setRequired(['intSchema', 'dateTime', 'name']);
+
+    const emailObj = { intSchema: 95, dateTime: '2023-08-21T07:56:45+12:12', name: 's.surendhar' };
+
+    const errMsg =
+        'Value {"intSchema":95,"dateTime":"2023-08-21T07:56:45+12:12","name":"s.surendhar"} is not of valid type(s)\n' +
+        'Type is missing in schema for declared DATETIME format.';
+
+    expect(() => SchemaValidator.validate([], objSchema, repo, emailObj)).toThrow(errMsg);
+});
+
+test('Schema Validator fail with dateTime test ', () => {
+    let intSchema: Schema = new Schema()
+        .setType(TypeUtil.of(SchemaType.INTEGER))
+        .setMaximum(3)
+        .setMultipleOf(5);
+
+    let objSchema: Schema = Schema.ofObject('testObj')
+        .setProperties(
+            new Map<string, Schema>([
+                ['intSchema', intSchema],
+                ['name', Schema.ofString('name').setMinLength(10)],
+                [
+                    'dateTime',
+                    new Schema()
+                        .setFormat(StringFormat.DATETIME)
+                        .setType(TypeUtil.of(SchemaType.STRING)),
+                ],
+            ]),
+        )
+        .setRequired(['dateTime']);
+
+    const dateTimeObj = { dateTime: '2023-08-221T07:56:45+12:12' };
+
+    const errMsg =
+        'Value {"dateTime":"2023-08-221T07:56:45+12:12"} is not of valid type(s)\n' +
+        'Value "2023-08-221T07:56:45+12:12" is not of valid type(s)\n' +
+        '2023-08-221T07:56:45+12:12 is not matched with the date time pattern';
+
+    expect(() => SchemaValidator.validate([], objSchema, repo, dateTimeObj)).toThrow(errMsg);
+});
+
+test('Schema Validator pass with time test ', () => {
+    let intSchema: Schema = new Schema().setType(TypeUtil.of(SchemaType.INTEGER));
+
+    let objSchema: Schema = Schema.ofObject('testObj')
+        .setProperties(
+            new Map<string, Schema>([
+                ['intSchema', intSchema],
+                ['name', Schema.ofString('name').setMinLength(10)],
+                [
+                    'dateTime',
+                    new Schema()
+                        .setFormat(StringFormat.DATETIME)
+                        .setType(TypeUtil.of(SchemaType.STRING)),
+                ],
+            ]),
+        )
+        .setRequired(['intSchema', 'dateTime']);
+
+    const dateTimeObj = {
+        intSchema: 95,
+        dateTime: '2023-08-21T07:56:45+12:12',
+        name: 's.surendhar',
+    };
+
+    expect(SchemaValidator.validate([], objSchema, repo, dateTimeObj)).toBe(dateTimeObj);
+});
+
+const dateTimeObj = { dateTime: '2023-08-21T07:56:45+12:12' };

--- a/kirun-js/package.json
+++ b/kirun-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fincity/kirun-js",
-    "version": "1.4.8",
+    "version": "1.4.9",
     "description": "Javascript Runtime for Kinetic Instructions",
     "source": "src/index.ts",
     "main": "dist/index.js",

--- a/kirun-js/package.json
+++ b/kirun-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fincity/kirun-js",
-    "version": "1.4.13",
+    "version": "1.4.14",
     "description": "Javascript Runtime for Kinetic Instructions",
     "source": "src/index.ts",
     "main": "dist/index.js",

--- a/kirun-js/package.json
+++ b/kirun-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fincity/kirun-js",
-    "version": "1.4.12",
+    "version": "1.4.13",
     "description": "Javascript Runtime for Kinetic Instructions",
     "source": "src/index.ts",
     "main": "dist/index.js",

--- a/kirun-js/src/engine/json/schema/validator/SchemaValidator.ts
+++ b/kirun-js/src/engine/json/schema/validator/SchemaValidator.ts
@@ -48,6 +48,14 @@ export class SchemaValidator {
             return SchemaValidator.enumCheck(parents, schema, element);
         }
 
+        if (schema.getFormat() && isNullValue(schema.getType()))
+            throw new SchemaValidationException(
+                this.path(parents),
+                'Type is missing in schema for declared ' +
+                    schema.getFormat()?.toString() +
+                    ' format.',
+            );
+
         if (schema.getType()) {
             SchemaValidator.typeValidation(parents, schema, repository, element);
         }


### PR DESCRIPTION
Corrected schema validator for String format with type string missing in schema and added testcases for both in kirun java and kirun js.